### PR TITLE
feat: add remove profile picture functionality

### DIFF
--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -34,9 +34,13 @@ export default {
         // h += `<h1>${i18n('account')}</h1>`;
 
         // profile picture
-        h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
+        h += `<div class="profile-picture-container" style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
+            // remove profile picture button - only show if user has a custom profile picture
+            if(window.user?.profile?.picture) {
+                h += `<button class="button button-danger remove-profile-picture" style="margin-top: 10px;">${i18n('remove_profile_picture')}</button>`;
+            }
         h += `</div>`;
 
         // change password button
@@ -174,8 +178,32 @@ export default {
                     $('.profile-image').addClass('profile-image-has-picture');
                     // update profile picture
                     update_profile(window.user.username, {picture: base64data})
+
+                    // Show the remove button after successful upload
+                    if (!$el_window.find('.remove-profile-picture').length) {
+                        $el_window.find('.profile-picture-container').append(`<button class="button button-danger remove-profile-picture" style="margin-top: 10px;">${i18n('remove_profile_picture')}</button>`);
+                    } else {
+                        // If button exists but is hidden, show it again
+                        $el_window.find('.remove-profile-picture').show();
+                    }
                 }
             }
+        })
+        
+        $el_window.on('click', '.remove-profile-picture', function(e) {
+            // Clear the profile picture data
+            update_profile(window.user.username, {picture: null});
+            
+            // Update the UI to show default avatar
+            $el_window.find('.profile-picture').css('background-image', 'url(' + window.icons['profile.svg'] + ')');
+            $('.profile-image').css('background-image', 'url(' + window.icons['profile.svg'] + ')');
+            $('.profile-image').removeClass('profile-image-has-picture');
+            
+            // Hide the remove button
+            $el_window.find('.remove-profile-picture').hide();
+            
+            // Update window.user.profile.picture to null
+            window.user.profile.picture = null;
         })
     },
 };

--- a/src/gui/src/i18n/translations/ar.js
+++ b/src/gui/src/i18n/translations/ar.js
@@ -252,6 +252,7 @@ const ar = {
       refresh: "تحديث",
       release_address_confirmation: "هل أنت متأكد أنك تريد تحرير هذا العنوان؟",
       remove_from_taskbar: "إزالة من شريط المهام",
+      remove_profile_picture: "إزالة صورة الملف الشخصي",
       rename: "إعادة تسمية",
       repeat: "تكرار",
       replace: "استبدال",

--- a/src/gui/src/i18n/translations/bn.js
+++ b/src/gui/src/i18n/translations/bn.js
@@ -237,6 +237,7 @@ const bn = {
     refresh: "রিফ্রেশ",
     release_address_confirmation: `আপনি কি নিশ্চিত যে আপনি এই ঠিকানা রিলিজ করতে চান?`,
     remove_from_taskbar: "টাস্কবার থেকে সরান",
+    remove_profile_picture: "প্রোফাইল ছবি সরান",
     rename: "পুনঃনামকরণ",
     repeat: "পুনরাবৃত্তি",
     replace: "বদলান",

--- a/src/gui/src/i18n/translations/br.js
+++ b/src/gui/src/i18n/translations/br.js
@@ -235,6 +235,7 @@ const br = {
     "refresh": "Atualizar",
     "release_address_confirmation": "Tem certeza de que deseja liberar este endereço?",
     "remove_from_taskbar": "Remover da Barra de Tarefas",
+    "remove_profile_picture": "Remover Foto do Perfil",
     "rename": "Renomear",
     "repeat": "Repetir",
     "replace": "Substituir",

--- a/src/gui/src/i18n/translations/da.js
+++ b/src/gui/src/i18n/translations/da.js
@@ -234,6 +234,7 @@ const da = {
 		refresh: 'Opdater',
 		release_address_confirmation: `Er du sikker på, at du vil frigive denne adresse?`,
 		remove_from_taskbar: 'Fjern fra proceslinje',
+		remove_profile_picture: 'Fjern Profilbillede',
 		rename: 'Omdøb',
 		repeat: 'Gentag',
 		replace: 'Erstat',

--- a/src/gui/src/i18n/translations/de.js
+++ b/src/gui/src/i18n/translations/de.js
@@ -234,6 +234,7 @@ const de = {
         refresh: 'Aktualisieren',
         release_address_confirmation: `Möchten Sie diese Adresse wirklich freigeben?`,
         remove_from_taskbar:'Von Taskleiste entfernen',
+        remove_profile_picture: "Profilbild Entfernen",
         rename: 'Umbenennen',
         repeat: 'Wiederholen',
         replace: 'Ersetzen',

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -238,6 +238,7 @@ const en = {
         refresh: 'Refresh',
         release_address_confirmation: `Are you sure you want to release this address?`,
         remove_from_taskbar:'Remove from Taskbar',
+        remove_profile_picture: 'Remove Profile Picture',
         rename: 'Rename',
         repeat: 'Repeat',
         replace: 'Replace',

--- a/src/gui/src/i18n/translations/es.js
+++ b/src/gui/src/i18n/translations/es.js
@@ -267,6 +267,7 @@ const es = {
     refresh: 'Refrescar',
     release_address_confirmation: `¿Estás seguro de que quieres liberar esta dirección?`,
     remove_from_taskbar: 'Eliminar de la barra de tareas',
+    remove_profile_picture: 'Eliminar Foto de Perfil',
     rename: 'Renombrar',
     repeat: 'Repetir',
     replace: 'Remplazar',

--- a/src/gui/src/i18n/translations/fa.js
+++ b/src/gui/src/i18n/translations/fa.js
@@ -135,6 +135,7 @@ const fa = {
     refresh: "تازه کردن",
     release_address_confirmation: `آیا مطمئن هستید که می خواهید این آدرس را آزاد کنید؟`,
     remove_from_taskbar: "از نوار وظایف حذف کن",
+    remove_profile_picture: "حذف تصویر پروفایل",
     rename: "تغییر نام",
     repeat: "تکرار",
     resend_confirmation_code: "ارسال مجدد کد تأیید",

--- a/src/gui/src/i18n/translations/fi.js
+++ b/src/gui/src/i18n/translations/fi.js
@@ -306,6 +306,7 @@ const fi = {
     // "publish" => "Oletko varma, että haluat julkaista tämän osoitteen?"
 
     remove_from_taskbar: "Poista tehtäväpalkista",
+    remove_profile_picture: "Poista Profiilikuva",
     rename: "Nimeä uudelleen",
     repeat: "Toista",
     replace: "Replace",

--- a/src/gui/src/i18n/translations/fr.js
+++ b/src/gui/src/i18n/translations/fr.js
@@ -234,6 +234,7 @@ const fr = {
         refresh: 'Actualiser',
         release_address_confirmation: `Etes-vous sûr de vouloir libérer cette adresse ?`,
         remove_from_taskbar: 'Retirer de la barre des tâches',
+        remove_profile_picture: "Supprimer la Photo de Profil",
         rename: 'Renommer',
         repeat: 'Répéter',
         replace: 'Remplacer',

--- a/src/gui/src/i18n/translations/he.js
+++ b/src/gui/src/i18n/translations/he.js
@@ -250,6 +250,7 @@ const en = {
     refresh: "רענן",
     release_address_confirmation: `האם אתה בטוח שברצונך לשחרר כתובת זו?`,
     remove_from_taskbar: "הסרה משורת המשימות",
+    remove_profile_picture: "הסר תמונת פרופיל",
     rename: "שנה שם",
     repeat: "חזור",
     replace: "החלף",

--- a/src/gui/src/i18n/translations/hi.js
+++ b/src/gui/src/i18n/translations/hi.js
@@ -234,6 +234,7 @@ const hi = {
         refresh: 'ताजा करना ',
         release_address_confirmation: "क्या आप वाकई यह पता जारी करना चाहते हैं?",
         remove_from_taskbar:'टास्कबार से हटाएँ',
+        remove_profile_picture: 'प्रोफ़ाइल चित्र हटाएँ',
         rename: 'नाम बदलें',
         repeat: 'दोहराना',
         replace: 'प्रतिस्थापित करें',

--- a/src/gui/src/i18n/translations/hu.js
+++ b/src/gui/src/i18n/translations/hu.js
@@ -230,6 +230,7 @@ const hu = {
         refresh: "Frissítés",
         release_address_confirmation: "Biztosan felszabadítod ezt a címet?",
         remove_from_taskbar: "Eltávolítás a tálcáról",
+        remove_profile_picture: "Profilkép Eltávolítása",
         rename: "Átnevezés",
         repeat: "Ismétlés",
         replace: "Csere",

--- a/src/gui/src/i18n/translations/hy.js
+++ b/src/gui/src/i18n/translations/hy.js
@@ -234,6 +234,7 @@ const hy = {
         refresh: "Թարմացնել",
         release_address_confirmation: "Իսկապե՞ս ուզում եք թողարկել այս հասցեն:",
         remove_from_taskbar: "Հանել խնդրագոտուց",
+        remove_profile_picture: "Հանել Պրոֆիլի Նկարը",
         rename: "Վերանվանել",
         repeat: "Կրկնել",
         replace: "Փոխարինել",

--- a/src/gui/src/i18n/translations/id.js
+++ b/src/gui/src/i18n/translations/id.js
@@ -251,6 +251,7 @@ const id = {
     refresh: "Memuat Ulang",
     release_address_confirmation: "Apakah Anda yakin ingin melepaskan alamat ini?",
     remove_from_taskbar: "Hapus dari Bilah Tugas",
+    remove_profile_picture: "Hapus Foto Profil",
     rename: "Ganti Nama",
     repeat: "Ulangi",
     replace: "Ganti",

--- a/src/gui/src/i18n/translations/ig.js
+++ b/src/gui/src/i18n/translations/ig.js
@@ -255,6 +255,7 @@ const ig = {
     refresh: "Weghachite ume",
     release_address_confirmation: `O doro gị anya na ịchọrọ wepụtara adreesị a?`,
     remove_from_taskbar: "Wepu na Taskbar",
+    remove_profile_picture: "Wepu Foto Profaịlụ",
     rename: "Nyegharịa aha",
     repeat: "megharịa",
     replace: "Dochie",

--- a/src/gui/src/i18n/translations/it.js
+++ b/src/gui/src/i18n/translations/it.js
@@ -258,6 +258,7 @@ const it = {
     refresh: "Ricarica",
     release_address_confirmation: `Sei sicuro di voler liberare questo indirizzo?`,
     remove_from_taskbar: "Sblocca dalla barra delle applicazioni",
+    remove_profile_picture: "Rimuovi Foto Profilo",
     rename: "Rinomina",
     repeat: "Ripeti",
     replace: "Sostituisci",

--- a/src/gui/src/i18n/translations/ja.js
+++ b/src/gui/src/i18n/translations/ja.js
@@ -235,6 +235,7 @@ const ja = {
         refresh: '更新',
         release_address_confirmation: `このアドレスを解放してもよろしいですか？`,
         remove_from_taskbar: 'タスクバーから削除',
+        remove_profile_picture: 'プロフィール画像を削除',
         rename: '名前を変更',
         repeat: '繰り返す',
         replace: '置換',

--- a/src/gui/src/i18n/translations/ko.js
+++ b/src/gui/src/i18n/translations/ko.js
@@ -253,6 +253,7 @@ const ko = {
     refresh: "새로 고침",
     release_address_confirmation: `이 주소를 해제하시겠습니까?`,
     remove_from_taskbar: "작업 표시줄에서 제거",
+    remove_profile_picture: "프로필 사진 삭제",
     rename: "이름 변경",
     repeat: "반복",
     replace: "교체",

--- a/src/gui/src/i18n/translations/ku.js
+++ b/src/gui/src/i18n/translations/ku.js
@@ -259,6 +259,7 @@ const ku = {
     refresh: "بوژانەوە",
     release_address_confirmation: `دڵنیایت کە ئەتەوێت ئەم ناونیشانە بۆ هەڵگرتن؟`,
     remove_from_taskbar: "لابردن لە تاکسبار",
+    remove_profile_picture: "لابردنی وێنەی پڕۆفایل",
     rename: "ناونانەوە",
     repeat: "دووبارەکردنەوە",
     replace: "لە نوێکردنەوە",

--- a/src/gui/src/i18n/translations/nb.js
+++ b/src/gui/src/i18n/translations/nb.js
@@ -136,6 +136,7 @@ const nb = {
         refresh: "Oppdater",
         release_address_confirmation: "Er du sikker på at du vil frigi denne adressen?",
         remove_from_taskbar: "Fjern fra oppgavelinjen",
+        remove_profile_picture: "Fjern Profilbilde",
         rename: "Gi nytt navn",
         repeat: "Gjenta",
         replace: 'Erstatt',

--- a/src/gui/src/i18n/translations/nl.js
+++ b/src/gui/src/i18n/translations/nl.js
@@ -235,6 +235,7 @@ const nl = {
 		refresh: 'Vernieuwen',
 		release_address_confirmation: `Weet je zeker dat je dit adres wilt vrijgeven?`,
 		remove_from_taskbar: 'Verwijderen van taakbalk',
+		remove_profile_picture: 'Profielfoto Verwijderen',
 		rename: 'Hernoemen',
 		repeat: 'Herhalen',
 		replace: 'Vervangen',

--- a/src/gui/src/i18n/translations/nn.js
+++ b/src/gui/src/i18n/translations/nn.js
@@ -124,6 +124,7 @@ const nn = {
         refresh: "Oppdater",
         release_address_confirmation: "Er du sikker på at du vil sleppe denne adressa?",
         remove_from_taskbar: "Fjern frå oppgåvelinja",
+        remove_profile_picture: "Fjern Profilbilde",
         rename: "Gje nytt namn",
         repeat: "Gjenta",
         resend_confirmation_code: "Send stadfestingskoden på nytt",

--- a/src/gui/src/i18n/translations/pl.js
+++ b/src/gui/src/i18n/translations/pl.js
@@ -234,6 +234,7 @@ const pl = {
         refresh: 'Odśwież',
         release_address_confirmation: `Jesteś pewien, że chcesz wypuścić ten adres?`,
         remove_from_taskbar:'Usuń z paska zadań',
+        remove_profile_picture: 'Usuń Zdjęcie Profilu',
         rename: 'Zmień nazwę',
         repeat: 'Powtarzaj',
         replace: 'Zamień',

--- a/src/gui/src/i18n/translations/pt.js
+++ b/src/gui/src/i18n/translations/pt.js
@@ -238,6 +238,7 @@ const pt = {
         refresh: 'Atualizar',
         release_address_confirmation: `Queres libertar este endereço?`,
         remove_from_taskbar:'Remover da Barra de Tarefas',
+        remove_profile_picture: 'Remover Foto de Perfil',
         rename: 'Renomear',
         repeat: 'Repetir',
         replace: 'Substituir',

--- a/src/gui/src/i18n/translations/ro.js
+++ b/src/gui/src/i18n/translations/ro.js
@@ -235,6 +235,7 @@ const ro = {
         refresh: 'Reîmprospătare',
         release_address_confirmation: `Sigur doriți să eliberați această adresă?`,
         remove_from_taskbar:'Eliminați din bara de activități',
+        remove_profile_picture: 'Eliminați Fotografia de Profil',
         rename: 'Redenumește',
         repeat: 'Repetă',
         replace: "Înlocuiește",

--- a/src/gui/src/i18n/translations/ru.js
+++ b/src/gui/src/i18n/translations/ru.js
@@ -258,6 +258,7 @@ const ru = {
     refresh: 'Обновить',
     release_address_confirmation: `Вы уверены, что хотите освободить этот адрес?`,
     remove_from_taskbar: 'Удалить из панели задач',
+    remove_profile_picture: 'Удалить фото профиля',
     rename: 'Переименовать',
     repeat: 'Повторить',
     replace: 'Заменить',

--- a/src/gui/src/i18n/translations/sv.js
+++ b/src/gui/src/i18n/translations/sv.js
@@ -235,6 +235,7 @@ const sv = {
         refresh: "Uppdatera",
         release_address_confirmation: "Är du säker på att du vill frigöra denna adress?",
         remove_from_taskbar: "Ta bort från aktivitetsfältet",
+        remove_profile_picture: "Ta bort Profilbild",
         rename: "Byt namn",
         repeat: "Upprepa",
         replace: "Ersätt",

--- a/src/gui/src/i18n/translations/ta.js
+++ b/src/gui/src/i18n/translations/ta.js
@@ -233,6 +233,7 @@ const ta = {
         refresh: 'புதுப்பிப்பு',
         release_address_confirmation: `இந்த முகவரியை நிச்சயமாக வெளியிட விரும்புகிறீர்களா?`,
         remove_from_taskbar: 'பணிப்பட்டியில் இருந்து அகற்று',
+        remove_profile_picture: 'சுயவிவரப் படத்தை அகற்று',
         rename: 'மறுபெயரிடவும்',
         repeat: 'மீண்டும் செய்யவும்',
         replace: 'மாற்றவும்',

--- a/src/gui/src/i18n/translations/th.js
+++ b/src/gui/src/i18n/translations/th.js
@@ -232,6 +232,7 @@ const th = {
         refresh: "รีเฟรช",
         release_address_confirmation: "คุณแน่ใจหรือไม่ว่าต้องการยกเลิกที่อยู่นี้?",
         remove_from_taskbar: "นำออกจากทาสก์บาร์",
+        remove_profile_picture: "ลบรูปโปรไฟล์",
         rename: "เปลี่ยนชื่อ",
         repeat: "ทำซ้ำ",
         replace: "แทนที่",

--- a/src/gui/src/i18n/translations/tr.js
+++ b/src/gui/src/i18n/translations/tr.js
@@ -234,6 +234,7 @@ const tr = {
         refresh: "Yenile",
         release_address_confirmation: "Bu adresi bırakmak istediğinize emin misiniz?",
         remove_from_taskbar: "Görev Çubuğundan Kaldır",
+        remove_profile_picture: "Profil Fotoğrafını Kaldır",
         rename: "Yeniden Adlandır",
         repeat: "Tekrarla",
         replace: "Değiştir",

--- a/src/gui/src/i18n/translations/ua.js
+++ b/src/gui/src/i18n/translations/ua.js
@@ -238,6 +238,7 @@ const ua = {
         refresh: "Оновити",
         release_address_confirmation: "Ви впевнені, що хочете звільнити цю адресу?",
         remove_from_taskbar: "Видалити з Панелі Завдань",
+        remove_profile_picture: "Видалити Фото Профілю",
         rename: "Перейменувати",
         repeat: "Повторити",
         replace: "Замінити",

--- a/src/gui/src/i18n/translations/ur.js
+++ b/src/gui/src/i18n/translations/ur.js
@@ -242,6 +242,7 @@ const ur = {
     refresh: "تازہ کریں ",
     release_address_confirmation: "ایڈریس کی تصدیق جاری ",
     remove_from_taskbar: "ٹاسک بار سے ہٹائیں ",
+    remove_profile_picture: "پروفائل تصویر ہٹائیں",
     rename: "دوبارہ نام دیں",
     repeat: "دہرایؐں",
     replace: "بدل دیں۔",

--- a/src/gui/src/i18n/translations/vi.js
+++ b/src/gui/src/i18n/translations/vi.js
@@ -235,6 +235,7 @@ const vi = {
         refresh: 'Làm mới',
         release_address_confirmation: `Bạn có chắc chắn muốn giải phóng địa chỉ này không?`,
         remove_from_taskbar: 'Xóa khỏi thanh tác vụ',
+        remove_profile_picture: 'Xóa Ảnh Đại Diện',
         rename: 'Đổi tên',
         repeat: 'Lặp lại',
         replace: 'Thay thế',

--- a/src/gui/src/i18n/translations/zh.js
+++ b/src/gui/src/i18n/translations/zh.js
@@ -235,6 +235,7 @@ const zh = {
         refresh: '刷新',
         release_address_confirmation: `您确定要释放此地址吗？`,
         remove_from_taskbar:'从任务栏中删除',
+        remove_profile_picture: '删除个人资料图片',
         rename: '重命名',
         repeat: '重复',
         replace: '替换',

--- a/src/gui/src/i18n/translations/zhtw.js
+++ b/src/gui/src/i18n/translations/zhtw.js
@@ -234,6 +234,7 @@ const zhtw = {
         refresh: '重新整理',
         release_address_confirmation: `您確定要釋放此地址嗎？`,
         remove_from_taskbar: '從工作列移除',
+        remove_profile_picture: '刪除個人資料圖片',
         rename: '重新命名',
         repeat: '重複',
         replace: '取代',


### PR DESCRIPTION
- Add remove_profile_picture translation key to all translations (except emoji)
- Implement remove button that appears conditionally when user has custom profile picture
- Add click handler to clear profile picture and revert to default avatar
- Support dynamic button show/hide for immediate UI updates after upload/remove
- Update both settings window and global profile elements consistently

Before:
<img width="1919" height="869" alt="Remove Profile Picture Button Before" src="https://github.com/user-attachments/assets/155b65c7-10dc-4149-a044-cb8f87e6b845" />


After:
<img width="1918" height="864" alt="Remove Profile Picture Button After" src="https://github.com/user-attachments/assets/6adda46e-ce75-4e83-9035-29c8c8bb75dc" />

Video Demo of Feature: https://youtu.be/C3DIyHI8rSc

Fixes #3 