### PR TITLE
fix: make sidebar header text color dynamic with theme lightness

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -1218,7 +1218,7 @@ span.header-sort-icon img {
     margin: 0;
     font-weight: bold;
     font-size: 13px;
-    color: #8f96a3;
+    color: var(--window-sidebar-color, #8f96a3) !important;
     text-shadow: 1px 1px rgb(247 247 247 / 15%);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -122,6 +122,10 @@ export class ThemeService extends Service {
         this.root.style.setProperty('--primary-alpha', s.alpha);
         this.root.style.setProperty('--primary-color', s.light_text ? 'white' : '#373e44');
 
+        // Sidebar header uses the same primary color for perfect sync with other UI elements
+        const primary = s.light_text ? '#ffffff' : '#373e44';
+        this.root.style.setProperty('--window-sidebar-color', primary);
+
         // TODO: Should we debounce this to reduce traffic?
         this.#broadcastService.sendBroadcast('themeChanged', {
             palette: {


### PR DESCRIPTION
- Update .window-sidebar-title to use --window-sidebar-color CSS variable
- Set --window-sidebar-color in ThemeService to match --primary-color
- Ensures sidebar headers change color in sync with other UI elements
- Fixes readability issues when adjusting theme lightness settings

Before:
<img width="1735" height="812" alt="Screenshot 2025-10-19 160124" src="https://github.com/user-attachments/assets/cc70e0b0-da90-4b9b-8f2b-d9f693fd6015" />

After:
<img width="1858" height="819" alt="Screenshot 2025-10-19 160143" src="https://github.com/user-attachments/assets/227f751c-e350-4237-ac60-19cb7a377f6f" />

Video demonstration: https://youtu.be/Wi3Jzw9d4YA

Fixes #4 